### PR TITLE
feat: refresh gradient styling

### DIFF
--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -82,7 +82,7 @@ export default function CommentList({ videoId }: CommentListProps) {
             value={content}
             onChange={(event) => setContent(event.target.value)}
             placeholder="Share your thoughts"
-            className="w-full rounded-lg border border-slate-800 bg-slate-900 p-3 text-sm focus:border-brand focus:outline-none"
+            className="w-full rounded-lg border border-white/10 bg-white/10 p-3 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
           />
           <button
             type="submit"
@@ -93,15 +93,15 @@ export default function CommentList({ videoId }: CommentListProps) {
           </button>
         </form>
       )}
-      {isLoading && <p className="text-sm text-slate-400">Loading comments...</p>}
+      {isLoading && <p className="text-sm text-slate-300">Loading comments...</p>}
       {error && <p className="text-sm text-red-400">{(error as Error).message}</p>}
       <ul className="space-y-4">
         {data?.comments.map((comment) => (
-          <li key={comment.id} className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+          <li key={comment.id} className="rounded-lg border border-white/10 bg-slate-950/70 p-4 backdrop-blur">
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-semibold text-white">{comment.authorName}</p>
-                <p className="text-xs text-slate-500">
+                <p className="text-xs text-slate-400">
                   {new Date(comment.createdAt).toLocaleString()}
                 </p>
               </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -24,8 +24,8 @@ export default function Layout() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-900">
+    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900 text-slate-100">
+      <header className="border-b border-white/10 bg-white/5 backdrop-blur">
         <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-4">
             <Link to="/" className="flex items-center gap-2 text-xl font-semibold">
@@ -45,7 +45,7 @@ export default function Layout() {
           </div>
           <form onSubmit={handleSubmit} className="flex w-full max-w-md items-center gap-2">
             <input
-              className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-brand focus:outline-none"
+              className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
               placeholder="Search videos"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
@@ -63,13 +63,13 @@ export default function Layout() {
                 <span className="hidden text-sm font-medium sm:inline">{user.displayName}</span>
                 <Link
                   to="/settings/profile"
-                  className="rounded-lg border border-slate-700 px-3 py-2 text-sm hover:border-brand"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-sm text-slate-100 hover:border-brand"
                 >
                   Settings
                 </Link>
                 <button
                   onClick={() => logout().catch(() => undefined)}
-                  className="rounded-lg bg-slate-800 px-3 py-2 text-sm hover:bg-slate-700"
+                  className="rounded-lg bg-white/10 px-3 py-2 text-sm text-slate-100 transition hover:bg-white/20"
                 >
                   Logout
                 </button>
@@ -88,7 +88,7 @@ export default function Layout() {
       <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6">
         <Outlet />
       </main>
-      <footer className="border-t border-slate-800 bg-slate-900 py-6 text-center text-xs text-slate-400">
+      <footer className="border-t border-white/10 bg-white/5 py-6 text-center text-xs text-slate-300 backdrop-blur">
         © {new Date().getFullYear()} CrownShield. Stream responsibly.
       </footer>
     </div>

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -49,10 +49,10 @@ export default function LikeButton({ videoId }: { videoId: string }) {
       disabled={!user || toggle.isPending}
       onClick={() => toggle.mutate()}
       className={clsx(
-        'flex items-center gap-2 rounded-lg border px-4 py-2 text-sm transition',
+        'flex items-center gap-2 rounded-lg border px-4 py-2 text-sm transition backdrop-blur',
         data?.liked
-          ? 'border-brand bg-brand/20 text-brand'
-          : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-brand'
+          ? 'border-brand/40 bg-brand/20 text-brand'
+          : 'border-white/10 bg-white/10 text-slate-200 hover:border-brand'
       )}
     >
       <span>{data?.liked ? '♥' : '♡'}</span>

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -9,7 +9,7 @@ export default function VideoCard({ video }: VideoCardProps) {
   return (
     <Link
       to={`/watch/${video.id}`}
-      className="flex flex-col gap-3 rounded-xl border border-slate-800 bg-slate-900 transition hover:border-brand"
+      className="flex flex-col gap-3 rounded-xl border border-white/10 bg-slate-950/70 transition hover:border-brand/60 backdrop-blur"
     >
       <div className="relative aspect-video overflow-hidden rounded-t-xl">
         <img src={video.posterUrl} alt={video.title} className="h-full w-full object-cover" />
@@ -19,13 +19,13 @@ export default function VideoCard({ video }: VideoCardProps) {
       </div>
       <div className="space-y-2 px-4 pb-4">
         <h3 className="text-sm font-semibold text-white line-clamp-2">{video.title}</h3>
-        <p className="text-xs text-slate-400">{video.channelName}</p>
-        <p className="text-xs text-slate-500">
+        <p className="text-xs text-slate-300">{video.channelName}</p>
+        <p className="text-xs text-slate-400">
           {video.views} views · {new Date(video.createdAt).toLocaleDateString()}
         </p>
-        <div className="flex flex-wrap gap-1 text-[11px] text-slate-400">
+        <div className="flex flex-wrap gap-1 text-[11px] text-slate-300">
           {video.tags.map((tag) => (
-            <span key={tag} className="rounded-full border border-slate-700 px-2 py-0.5">
+            <span key={tag} className="rounded-full border border-white/10 px-2 py-0.5">
               #{tag}
             </span>
           ))}

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@
 }
 
 body {
-  @apply bg-slate-950 text-slate-50 min-h-screen;
+  @apply min-h-screen bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900 text-slate-50;
 }
 
 a {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -34,67 +34,69 @@ export default function AuthPage() {
   };
 
   return (
-    <div className="mx-auto max-w-md space-y-6 rounded-2xl border border-slate-800 bg-slate-900 p-8">
-      <header className="space-y-1">
-        <h1 className="text-xl font-semibold text-white">
-          {mode === 'login' ? 'Welcome back' : 'Create your channel'}
-        </h1>
-        <p className="text-sm text-slate-400">
-          {mode === 'login'
-            ? 'Sign in to continue watching and upload your own videos.'
-            : 'Register to unlock uploads, likes, and comments.'}
-        </p>
-      </header>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <label className="block space-y-2">
-          <span className="text-sm font-semibold text-slate-200">Email</span>
-          <input
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-brand focus:outline-none"
-            required
-          />
-        </label>
-        <label className="block space-y-2">
-          <span className="text-sm font-semibold text-slate-200">Password</span>
-          <input
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-brand focus:outline-none"
-            required
-          />
-        </label>
-        {mode === 'register' && (
+    <div className="mx-auto max-w-md overflow-hidden rounded-2xl bg-gradient-to-tr from-brand/60 via-purple-500/40 to-sky-500/40 p-[1px] shadow-xl">
+      <div className="space-y-6 rounded-2xl bg-slate-950/80 p-8 backdrop-blur">
+        <header className="space-y-1">
+          <h1 className="text-xl font-semibold text-white">
+            {mode === 'login' ? 'Welcome back' : 'Create your channel'}
+          </h1>
+          <p className="text-sm text-slate-300">
+            {mode === 'login'
+              ? 'Sign in to continue watching and upload your own videos.'
+              : 'Register to unlock uploads, likes, and comments.'}
+          </p>
+        </header>
+        <form onSubmit={handleSubmit} className="space-y-4">
           <label className="block space-y-2">
-            <span className="text-sm font-semibold text-slate-200">Channel name</span>
+            <span className="text-sm font-semibold text-slate-200">Email</span>
             <input
-              value={displayName}
-              onChange={(event) => setDisplayName(event.target.value)}
-              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-brand focus:outline-none"
-              required={mode === 'register'}
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
+              required
             />
           </label>
-        )}
-        {error && <p className="text-sm text-red-400">{error}</p>}
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-white hover:bg-brand-dark disabled:opacity-70"
-        >
-          {loading ? 'Please wait...' : mode === 'login' ? 'Sign in' : 'Register'}
-        </button>
-      </form>
-      <p className="text-sm text-slate-400">
-        {mode === 'login' ? 'No account yet?' : 'Already a member?'}{' '}
-        <button
-          className="text-brand hover:text-brand-dark"
-          onClick={() => setMode(mode === 'login' ? 'register' : 'login')}
-        >
-          {mode === 'login' ? 'Join CrownShield' : 'Sign in instead'}
-        </button>
-      </p>
+          <label className="block space-y-2">
+            <span className="text-sm font-semibold text-slate-200">Password</span>
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
+              required
+            />
+          </label>
+          {mode === 'register' && (
+            <label className="block space-y-2">
+              <span className="text-sm font-semibold text-slate-200">Channel name</span>
+              <input
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+                className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
+                required={mode === 'register'}
+              />
+            </label>
+          )}
+          {error && <p className="text-sm text-red-400">{error}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-white hover:bg-brand-dark disabled:opacity-70"
+          >
+            {loading ? 'Please wait...' : mode === 'login' ? 'Sign in' : 'Register'}
+          </button>
+        </form>
+        <p className="text-sm text-slate-300">
+          {mode === 'login' ? 'No account yet?' : 'Already a member?'}{' '}
+          <button
+            className="text-brand hover:text-brand-dark"
+            onClick={() => setMode(mode === 'login' ? 'register' : 'login')}
+          >
+            {mode === 'login' ? 'Join CrownShield' : 'Sign in instead'}
+          </button>
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/pages/Channel.tsx
+++ b/src/pages/Channel.tsx
@@ -29,14 +29,14 @@ export default function Channel() {
 
   return (
     <div className="space-y-6">
-      <header className="rounded-2xl border border-slate-800 bg-slate-900 p-8">
+      <header className="rounded-2xl border border-white/10 bg-slate-950/70 p-8 backdrop-blur">
         <h1 className="text-2xl font-semibold text-white">{channelName}</h1>
-        <p className="mt-2 text-sm text-slate-400">
+        <p className="mt-2 text-sm text-slate-300">
           {channelVideos.length} videos · Member since{' '}
           {channelVideos[0] ? new Date(channelVideos[0].createdAt).toLocaleDateString() : 'recently'}
         </p>
       </header>
-      {isLoading && <p className="text-sm text-slate-400">Loading channel...</p>}
+      {isLoading && <p className="text-sm text-slate-300">Loading channel...</p>}
       {error && <p className="text-sm text-red-400">{(error as Error).message}</p>}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {channelVideos.map((video) => (

--- a/src/pages/ProfileSettings.tsx
+++ b/src/pages/ProfileSettings.tsx
@@ -42,13 +42,16 @@ export default function ProfileSettings() {
         <h1 className="text-2xl font-semibold text-white">Profile settings</h1>
         <p className="text-sm text-slate-400">Control how your channel appears across CrownShield.</p>
       </header>
-      <form onSubmit={handleSubmit} className="space-y-5 rounded-2xl border border-slate-800 bg-slate-900 p-6">
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-5 rounded-2xl border border-white/10 bg-slate-950/70 p-6 backdrop-blur shadow-lg"
+      >
         <label className="block space-y-2">
           <span className="text-sm font-semibold text-slate-200">Display name</span>
           <input
             value={displayName}
             onChange={(event) => setDisplayName(event.target.value)}
-            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-brand focus:outline-none"
+            className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
           />
         </label>
         <label className="block space-y-2">
@@ -57,7 +60,7 @@ export default function ProfileSettings() {
             value={bio}
             onChange={(event) => setBio(event.target.value)}
             rows={4}
-            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-brand focus:outline-none"
+            className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
           />
         </label>
         <label className="block space-y-2">
@@ -65,7 +68,7 @@ export default function ProfileSettings() {
           <input
             value={avatarUrl}
             onChange={(event) => setAvatarUrl(event.target.value)}
-            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-brand focus:outline-none"
+            className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
           />
         </label>
         {message && <p className="text-sm text-slate-300">{message}</p>}
@@ -80,7 +83,7 @@ export default function ProfileSettings() {
           <button
             type="button"
             onClick={() => navigate(-1)}
-            className="rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-300 hover:border-brand"
+            className="rounded-lg border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-brand"
           >
             Cancel
           </button>

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -191,13 +191,13 @@ export default function Upload() {
     <div className="space-y-8">
       <header className="space-y-2">
         <h1 className="text-2xl font-semibold text-white">Upload new video</h1>
-        <p className="text-sm text-slate-400">
+        <p className="text-sm text-slate-300">
           Share your latest creation with the CrownShield community. Hi {user?.displayName}!
         </p>
       </header>
       <form onSubmit={handleSubmit} className="space-y-6">
         {uploadLimit && (
-          <p className="text-sm text-slate-400">Maximum file size: {(uploadLimit / (1024 * 1024)).toFixed(0)} MB</p>
+          <p className="text-sm text-slate-300">Maximum file size: {(uploadLimit / (1024 * 1024)).toFixed(0)} MB</p>
         )}
         <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
           <div className="space-y-6">
@@ -207,7 +207,7 @@ export default function Upload() {
                 type="file"
                 accept="video/mp4"
                 onChange={handleVideoChange}
-                className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm"
+                className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 file:mr-4 file:rounded-md file:border-0 file:bg-brand file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white"
               />
             </label>
             {videoPreview && (
@@ -217,7 +217,7 @@ export default function Upload() {
                   src={videoPreview}
                   controls
                   onLoadedMetadata={(event) => setDuration((event.target as HTMLVideoElement).duration)}
-                  className="w-full rounded-xl border border-slate-800"
+                  className="w-full rounded-xl border border-white/10 bg-black/80"
                 />
                 <button
                   type="button"
@@ -230,20 +230,20 @@ export default function Upload() {
                   <img
                     src={posterPreview}
                     alt="Poster preview"
-                    className="w-full rounded-xl border border-slate-800"
+                    className="w-full rounded-xl border border-white/10"
                   />
                 )}
                 <canvas ref={canvasRef} className="hidden" />
               </div>
             )}
           </div>
-          <aside className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900 p-6">
+          <aside className="space-y-4 rounded-2xl border border-white/10 bg-slate-950/70 p-6 backdrop-blur shadow-lg">
             <label className="block space-y-2">
               <span className="text-sm font-semibold text-slate-200">Title</span>
               <input
                 value={title}
                 onChange={(event) => setTitle(event.target.value)}
-                className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-brand focus:outline-none"
+                className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
               />
             </label>
             <label className="block space-y-2">
@@ -252,7 +252,7 @@ export default function Upload() {
                 value={description}
                 onChange={(event) => setDescription(event.target.value)}
                 rows={5}
-                className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-brand focus:outline-none"
+                className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
               />
             </label>
             <label className="block space-y-2">
@@ -260,16 +260,16 @@ export default function Upload() {
               <input
                 value={tags}
                 onChange={(event) => setTags(event.target.value)}
-                className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-brand focus:outline-none"
+                className="w-full rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-brand focus:outline-none"
               />
             </label>
             {progress > 0 && (
               <div className="space-y-2 text-sm">
-                <div className="flex items-center justify-between">
-                  <span className="text-slate-300">Uploading</span>
-                  <span className="text-slate-400">{progress}%</span>
+                <div className="flex items-center justify-between text-slate-300">
+                  <span>Uploading</span>
+                  <span>{progress}%</span>
                 </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
+                <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
                   <div
                     className="h-full bg-brand"
                     style={{ width: `${progress}%` }}

--- a/src/pages/Watch.tsx
+++ b/src/pages/Watch.tsx
@@ -60,7 +60,7 @@ export default function Watch() {
   return (
     <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
       <div className="space-y-6">
-        <div className="overflow-hidden rounded-2xl border border-slate-800 bg-black">
+        <div className="overflow-hidden rounded-2xl border border-white/10 bg-black/80 shadow-lg">
           <video
             src={video.videoUrl}
             poster={video.posterUrl}
@@ -70,7 +70,7 @@ export default function Watch() {
         </div>
         <div className="space-y-3">
           <h1 className="text-2xl font-semibold text-white">{video.title}</h1>
-          <div className="flex flex-wrap items-center gap-3 text-sm text-slate-400">
+          <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
             <span>{video.channelName}</span>
             <span>•</span>
             <span>{video.views} views</span>
@@ -78,11 +78,11 @@ export default function Watch() {
             <span>{new Date(video.createdAt).toLocaleDateString()}</span>
             <LikeButton videoId={video.id} />
           </div>
-          <div className="space-y-2 rounded-xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-200">
+          <div className="space-y-2 rounded-xl border border-white/10 bg-slate-950/70 p-4 text-sm text-slate-200 backdrop-blur">
             <p className="whitespace-pre-wrap">{video.description}</p>
-            <div className="flex flex-wrap gap-2 text-xs text-slate-400">
+            <div className="flex flex-wrap gap-2 text-xs text-slate-300">
               {video.tags.map((tag) => (
-                <span key={tag} className="rounded-full border border-slate-700 px-2 py-0.5">
+                <span key={tag} className="rounded-full border border-white/10 px-2 py-0.5">
                   #{tag}
                 </span>
               ))}


### PR DESCRIPTION
## Summary
- apply a gradient background theme globally and soften the layout header and footer with translucent overlays for readability
- refresh the auth card with a gradient frame and translucent surface to match the updated palette
- update key pages and shared components to use translucent panels and higher-contrast text on the new gradient backdrop

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ded474ccfc8325afe00d161d857105