### PR TITLE
Fix JSON body parsing in API helper

### DIFF
--- a/api/_lib/body.ts
+++ b/api/_lib/body.ts
@@ -1,7 +1,15 @@
 import type { VercelRequest } from '@vercel/node';
 
 export async function readJsonBody<T = unknown>(req: VercelRequest): Promise<T | null> {
-  if (req.body) {
+  if (req.body !== undefined && req.body !== null) {
+    if (typeof req.body === 'string') {
+      return JSON.parse(req.body) as T;
+    }
+
+    if (req.body instanceof Buffer) {
+      return JSON.parse(req.body.toString('utf8')) as T;
+    }
+
     return req.body as T;
   }
 


### PR DESCRIPTION
## Summary
- parse string and Buffer request bodies so API routes receive proper JSON objects before validation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfec5f7ab4832593c9ee7bdfb3a8d0